### PR TITLE
Fix booking update field mismatch

### DIFF
--- a/backend/crud/bookings.py
+++ b/backend/crud/bookings.py
@@ -75,7 +75,7 @@ def update_booking(session: Session, db_booking: Booking, updated_data: Booking)
     db_booking.phone = updated_data.phone
     db_booking.service_id = updated_data.service_id
     db_booking.message = updated_data.message
-    db_booking.appointment_date = updated_data.appointment_date
+    db_booking.appointment_time = updated_data.appointment_time
 
     session.commit()
     session.refresh(db_booking)


### PR DESCRIPTION
## Summary
- fix appointment field name in booking update logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ee0914140832bbe37968ee009b5e2